### PR TITLE
Add vector Rank Normal to kernel-loader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(${CMAKE_BINARY_DIR}/arrow_vendored/cpp/src/)
 
 # Add source files
 add_library(arrow_kernel_loader SHARED
+        ${CMAKE_BINARY_DIR}/arrow_vendored/cpp/src/arrow/util/math_internal.cc
         ${CMAKE_BINARY_DIR}/arrow_vendored/cpp/src/arrow/compute/kernels/chunked_internal.cc
         ${CMAKE_BINARY_DIR}/arrow_vendored/cpp/src/arrow/chunk_resolver.cc
         ${CMAKE_BINARY_DIR}/arrow_vendored/cpp/src/arrow/compute/api_vector.cc

--- a/ci/scripts/build_kernel_loader.sh
+++ b/ci/scripts/build_kernel_loader.sh
@@ -10,7 +10,7 @@ pushd ${build_dir}
 mkdir arrow_tmp
 pushd arrow_tmp
 
-sha="d3c467625d83bd69e2b85a289f810ec5b2789d63"
+sha="784aa6faf69f5cf135e09976a281dea9ebf58166"
 
 # Download Arrow source code
 url="https://github.com/apache/arrow/archive/${sha}.zip"
@@ -34,6 +34,8 @@ mv arrow_tmp/arrow-${sha}/cpp/src/arrow/compute/api_vector.cc arrow_vendored/cpp
 mv arrow_tmp/arrow-${sha}/cpp/src/arrow/compute/api_vector.h arrow_vendored/cpp/src/arrow/compute/
 mv arrow_tmp/arrow-${sha}/cpp/src/arrow/compute/function_internal.h arrow_vendored/cpp/src/arrow/compute/
 mv arrow_tmp/arrow-${sha}/cpp/src/arrow/compute/kernels/chunked_internal.cc arrow_vendored/cpp/src/arrow/compute/kernels/
+mv arrow_tmp/arrow-${sha}/cpp/src/arrow/util/math_internal.h arrow_vendored/cpp/src/arrow/util/
+mv arrow_tmp/arrow-${sha}/cpp/src/arrow/util/math_internal.cc arrow_vendored/cpp/src/arrow/util/
 mv arrow_tmp/arrow-${sha}/cpp/src/arrow/util/reflection_internal.h arrow_vendored/cpp/src/arrow/util/
 mv arrow_tmp/arrow-${sha}/cpp/src/arrow/compute/kernels/vector_sort_internal.h arrow_vendored/cpp/src/arrow/compute/kernels/
 mv arrow_tmp/arrow-${sha}/cpp/src/arrow/compute/kernels/chunked_internal.h arrow_vendored/cpp/src/arrow/compute/kernels/

--- a/src/rank_kernel.patch
+++ b/src/rank_kernel.patch
@@ -400,19 +400,19 @@ index 2a492f581f..0832399be4 100644
        return Generator<Type0, Decimal128Type, Args...>::Exec;
      case Type::DECIMAL256:
 diff --git a/cpp/src/arrow/compute/kernels/vector_rank.cc b/cpp/src/arrow/compute/kernels/vector_rank.cc
-index 2efc61c2e6..21fc9a3dbb 100644
+index d1323c2030..73c050d933 100644
 --- a/cpp/src/arrow/compute/kernels/vector_rank.cc
 +++ b/cpp/src/arrow/compute/kernels/vector_rank.cc
-@@ -22,7 +22,7 @@
- #include "arrow/compute/kernels/vector_sort_internal.h"
+@@ -23,7 +23,7 @@
  #include "arrow/compute/registry.h"
+ #include "arrow/util/math_internal.h"
  
 -namespace arrow::compute::internal {
 +namespace arrow::compute::internal::vendored {
  
  using ::arrow::util::span;
  
-@@ -80,7 +80,7 @@ Result<NullPartitionResult> DoSortAndMarkDuplicate(
+@@ -71,7 +71,7 @@ Result<NullPartitionResult> DoSortAndMarkDuplicate(
    using GetView = GetViewType<ArrowType>;
    using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
  
@@ -421,26 +421,35 @@ index 2efc61c2e6..21fc9a3dbb 100644
  
    ArrayType array(input.data());
    ARROW_ASSIGN_OR_RAISE(auto sorted,
-@@ -361,7 +361,7 @@ class RankMetaFunction : public RankMetaFunctionBase<RankMetaFunction> {
+@@ -380,7 +380,7 @@ class RankMetaFunction : public RankMetaFunctionBase<RankMetaFunction> {
    }
  
    RankMetaFunction()
--      : RankMetaFunctionBase("rank", Arity::Unary(), rank_doc, GetDefaultRankOptions()) {}
-+      : RankMetaFunctionBase("vendored_rank", Arity::Unary(), rank_doc, GetDefaultRankOptions()) {}
- };
+-      : RankMetaFunctionBase("rank", Arity::Unary(), rank_doc, &kDefaultOptions) {}
++      : RankMetaFunctionBase("vendored_rank", Arity::Unary(), rank_doc, &kDefaultOptions) {}
  
- class RankQuantileMetaFunction : public RankMetaFunctionBase<RankQuantileMetaFunction> {
-@@ -374,7 +374,7 @@ class RankQuantileMetaFunction : public RankMetaFunctionBase<RankQuantileMetaFun
+   static inline const auto kDefaultOptions = RankOptions::Defaults();
+ };
+@@ -396,7 +396,7 @@ class RankQuantileMetaFunction : public RankMetaFunctionBase<RankQuantileMetaFun
    static RankerType GetRanker(const RankQuantileOptions& options) { return RankerType(); }
  
    RankQuantileMetaFunction()
 -      : RankMetaFunctionBase("rank_quantile", Arity::Unary(), rank_quantile_doc,
 +      : RankMetaFunctionBase("vendored_rank_quantile", Arity::Unary(), rank_quantile_doc,
-                              GetDefaultQuantileRankOptions()) {}
- };
+                              &kDefaultOptions) {}
  
-@@ -385,4 +385,4 @@ void RegisterVectorRank(FunctionRegistry* registry) {
-   DCHECK_OK(registry->AddFunction(std::make_shared<RankQuantileMetaFunction>()));
+   static inline const auto kDefaultOptions = RankQuantileOptions::Defaults();
+@@ -413,7 +413,7 @@ class RankNormalMetaFunction : public RankMetaFunctionBase<RankNormalMetaFunctio
+   static RankerType GetRanker(const RankQuantileOptions& options) { return RankerType(); }
+ 
+   RankNormalMetaFunction()
+-      : RankMetaFunctionBase("rank_normal", Arity::Unary(), rank_normal_doc,
++      : RankMetaFunctionBase("vendored_rank_normal", Arity::Unary(), rank_normal_doc,
+                              &kDefaultOptions) {}
+ 
+   static inline const auto kDefaultOptions = RankQuantileOptions::Defaults();
+@@ -427,4 +427,4 @@ void RegisterVectorRank(FunctionRegistry* registry) {
+   DCHECK_OK(registry->AddFunction(std::make_shared<RankNormalMetaFunction>()));
  }
  
 -}  // namespace arrow::compute::internal

--- a/tests/test_main.cc
+++ b/tests/test_main.cc
@@ -36,6 +36,12 @@ int main() {
         return -1;
     }
 
+    result = arrow::compute::CallFunction("vendored_rank_normal", {datums}, &options);
+    if (!result.ok()) {
+        std::cerr << "Failed to call function: " << result.status().ToString() << std::endl;
+        return -1;
+    }
+
     std::cout << result->ToString() << std::endl;
     return 0;
 }


### PR DESCRIPTION
Updates the patch to solve conflicts to apply to current latest upstream and adds the rank_normal function to the vendored kernels.